### PR TITLE
decoupled physics body and collider creation

### DIFF
--- a/engine/Controller/Lua/LuaManger.cpp
+++ b/engine/Controller/Lua/LuaManger.cpp
@@ -250,7 +250,7 @@ void LuaManager::Expose_Engine() {
 	//expose physics
 	Expose_CPPClass<PhysicsManager>("PhysicsManager",
 		sol::no_constructor,
-		"AddPhysicsBody", &PhysicsManager::AddPhysicsBody,
+		"AddPhysicsBody", &PhysicsManager::CreatePhysicsBody,
 		"AddSphereCollider", &PhysicsManager::AddSphereCollider,
 		"AddBoxCollider", &PhysicsManager::AddBoxCollider,
 		"AddCapsuleCollider", &PhysicsManager::AddCapsuleCollider,
@@ -265,8 +265,7 @@ void LuaManager::Expose_Engine() {
 		"GetPosition", &PhysicsBody::GetPosition,
 		"GetRotation", &PhysicsBody::GetRotation,
 		"SetPosition", &PhysicsBody::SetPosition,
-		"SetRotation", &PhysicsBody::SetRotation,
-		"GetID", &PhysicsBody::GetID
+		"SetRotation", &PhysicsBody::SetRotation
 		);
 
 

--- a/engine/Controller/Physics/PhysicsManager.cpp
+++ b/engine/Controller/Physics/PhysicsManager.cpp
@@ -35,55 +35,56 @@ void PhysicsManager::Update(double deltaTime)
 	rp3dWorld->testCollision(mCallback);
 }
 
-PhysicsBody& PhysicsManager::AddPhysicsBody(GameObject& go)
+void PhysicsManager::CreatePhysicsBody(int ID)
 {
 	//add collision body to react and get its ID
 	rp3d::Vector3 pos(0.0, 0.0, 0.0);
 	rp3d::CollisionBody* bPtr;
-	bPtr = rp3dWorld->createCollisionBody({ {go.position.x, go.position.y, go.position.z},rp3d::Quaternion::identity() });
-	unsigned int id = bPtr->getEntity().id;
+	bPtr = rp3dWorld->createCollisionBody({ pos,rp3d::Quaternion::identity() });
 
 	//create a physics body and set ID.
 	PhysicsBody pb;
 	pb.body = bPtr;
-	pb.ID = id;
-	physicsBodies.insert({id,pb});
-
-	//assign rigidbody to gameobject
-	//maybe it should be the other way around? PhysicsBody has game object refernce?
-	go.physicsBody = &physicsBodies.at(id);
-
-	return physicsBodies.at(id);
+	physicsBodies.insert({ID,pb});
 }
 
-void PhysicsManager::AddSphereCollider(PhysicsBody& pb, float radius)
+void PhysicsManager::AddSphereCollider(int ID, float radius)
 {
-	SphereShape* shape = rp3dPhysicsCommon.createSphereShape(radius);
-	rp3d::Collider* rpCollider = pb.body->addCollider(shape, Transform::identity());
+	if (physicsBodies[ID].body != nullptr)
+	{
+		SphereShape* shape = rp3dPhysicsCommon.createSphereShape(radius);
+		rp3d::Collider* rpCollider = physicsBodies[ID].body->addCollider(shape, Transform::identity());
 
-	SphereCollider collider;
-	collider.rp3dCollider = rpCollider;
-	pb.colliders.push_back(collider);
+		SphereCollider collider;
+		collider.rp3dCollider = rpCollider;
+		physicsBodies[ID].colliders.push_back(collider);
+	}
 }
 
-void PhysicsManager::AddBoxCollider(PhysicsBody& pb, glm::vec3 scale)
+void PhysicsManager::AddBoxCollider(int ID, glm::vec3 scale)
 {
-	BoxShape* shape = rp3dPhysicsCommon.createBoxShape(Vector3(scale.x, scale.y, scale.z));
-	rp3d::Collider* rpCollider = pb.body->addCollider(shape, Transform::identity());
+	if (physicsBodies[ID].body != nullptr)
+	{
+		BoxShape* shape = rp3dPhysicsCommon.createBoxShape(Vector3(scale.x, scale.y, scale.z));
+		rp3d::Collider* rpCollider = physicsBodies[ID].body->addCollider(shape, Transform::identity());
 
-	BoxCollider collider;
-	collider.rp3dCollider = rpCollider;
-	pb.colliders.push_back(collider);
+		BoxCollider collider;
+		collider.rp3dCollider = rpCollider;
+		physicsBodies[ID].colliders.push_back(collider);
+	}
 }
 
-void PhysicsManager::AddCapsuleCollider(PhysicsBody& pb, float radius, float height)
+void PhysicsManager::AddCapsuleCollider(int ID, float radius, float height)
 {
-	CapsuleShape* shape = rp3dPhysicsCommon.createCapsuleShape(radius, height);
-	rp3d::Collider* rpCollider = pb.body->addCollider(shape, Transform::identity());
+	if (physicsBodies[ID].body != nullptr)
+	{
+		CapsuleShape* shape = rp3dPhysicsCommon.createCapsuleShape(radius, height);
+		rp3d::Collider* rpCollider = physicsBodies[ID].body->addCollider(shape, Transform::identity());
 
-	CapsuleCollider collider;
-	collider.rp3dCollider = rpCollider;
-	pb.colliders.push_back(collider);
+		CapsuleCollider collider;
+		collider.rp3dCollider = rpCollider;
+		physicsBodies[ID].colliders.push_back(collider);
+	}
 }
 
 void PhysicsManager::DrawPhysicsWorld(Camera& camera)

--- a/engine/Controller/Physics/PhysicsManager.h
+++ b/engine/Controller/Physics/PhysicsManager.h
@@ -43,7 +43,7 @@ public:
 		*	@param go - game object to add a physicsbody to
 		*	@return Created physics body
 		*/
-	PhysicsBody& AddPhysicsBody(GameObject& go);
+	void CreatePhysicsBody(int ID);
 
 		/**
 		*	@brief add sphere collider to supplied physics body
@@ -51,7 +51,7 @@ public:
 		*	@param radius - radius of sphere collider
 		*	@return void
 		*/
-	void AddSphereCollider(PhysicsBody& pb, float radius);
+	void AddSphereCollider(int ID, float radius);
 		
 		/**
 		*	@brief add box collider to supplied physics body
@@ -59,7 +59,7 @@ public:
 		*	@param scale - x,y and z axis size of the box collider
 		*	@return void
 		*/
-	void AddBoxCollider(PhysicsBody& pb, glm::vec3 scale);
+	void AddBoxCollider(int ID, glm::vec3 scale);
 
 		/**
 		*	@brief add capsule collider to supplied physics body
@@ -68,7 +68,7 @@ public:
 		*	@param height - height of capsule colluder
 		*	@return void
 		*/
-	void AddCapsuleCollider(PhysicsBody& pb, float radius, float height);
+	void AddCapsuleCollider(int ID, float radius, float height);
 
 		/**
 		*	@brief resolves the collision between two physicsbodies

--- a/engine/Controller/Physics/RigidBody.cpp
+++ b/engine/Controller/Physics/RigidBody.cpp
@@ -62,7 +62,8 @@ unsigned int PhysicsBody::GetNumColliders()
 	return colliders.size();
 }
 
+/*
 unsigned int PhysicsBody::GetID()
 {
 	return ID;
-}
+}*/

--- a/engine/Controller/Physics/RigidBody.h
+++ b/engine/Controller/Physics/RigidBody.h
@@ -89,13 +89,13 @@ public:
 		*	@brief return physicsbody ID in physics world
 		*	@return ID of physics body
 		*/
-	unsigned int GetID();
+	//unsigned int GetID();
 
 	friend class PhysicsManager;
 
 private:
 
-	unsigned int ID = -1;
+	//unsigned int ID = -1;
 
 
 	std::vector<PhysicsCollider> colliders;

--- a/engine/Controller/Serialization/SceneLoader.cpp
+++ b/engine/Controller/Serialization/SceneLoader.cpp
@@ -324,7 +324,7 @@ Scene& SceneLoader::LoadScene(const char* inName)
         //physics properties
         PhysicsManager& physicsManager = PhysicsManager::Get();
 
-        PhysicsBody pb = physicsManager.AddPhysicsBody(*go);
+        physicsManager.CreatePhysicsBody(i);
         for (int i = 0; i < jobj["physics"].size(); i++)
         {
             glm::vec3 nOffset;
@@ -347,16 +347,16 @@ Scene& SceneLoader::LoadScene(const char* inName)
                 nScale.x = jobj["physics"][i]["scale"][0].asFloat();
                 nScale.y = jobj["physics"][i]["scale"][1].asFloat();
                 nScale.z = jobj["physics"][i]["scale"][2].asFloat();
-                physicsManager.AddBoxCollider(*go->physicsBody,nScale);
+                physicsManager.AddBoxCollider(i,nScale);
                 break;
             case COLLIDER_SPHERE:
                 nRadius = jobj["physics"][i]["radius"].asFloat();
-                physicsManager.AddSphereCollider(*go->physicsBody,nRadius);
+                physicsManager.AddSphereCollider(i,nRadius);
                 break;
             case COLLIDER_CAPSULE:
                 nRadius = jobj["physics"][i]["radius"].asFloat();
                 nHeight = jobj["physics"][i]["height"].asFloat();
-                physicsManager.AddCapsuleCollider(*go->physicsBody, nRadius, nHeight);
+                physicsManager.AddCapsuleCollider(i, nRadius, nHeight);
                 break;
 
             default:

--- a/engine/Editor/SceneEditor.cpp
+++ b/engine/Editor/SceneEditor.cpp
@@ -244,7 +244,7 @@ void SceneEditor::DrawHeighrarchy()
 				go = *pair.second;
 				go.name = nName;
 
-				physicsManager.AddPhysicsBody(go);
+				physicsManager.CreatePhysicsBody(go.GetID());
 				
 				if(pair.second->physicsBody)
 				for (int i = 0; i < pair.second->physicsBody->GetNumColliders(); ++i)
@@ -253,13 +253,13 @@ void SceneEditor::DrawHeighrarchy()
 					switch (pair.second->physicsBody->GetCollider(i).GetType())
 					{
 					case COLLIDER_BOX:
-						physicsManager.AddBoxCollider(*go.physicsBody,static_cast<BoxCollider*>(&nCollider)->GetScale());
+						physicsManager.AddBoxCollider(go.GetID(),static_cast<BoxCollider*>(&nCollider)->GetScale());
 						break;
 					case COLLIDER_SPHERE:
-						physicsManager.AddSphereCollider(*go.physicsBody, static_cast<SphereCollider*>(&nCollider)->GetRadius());
+						physicsManager.AddSphereCollider(go.GetID(), static_cast<SphereCollider*>(&nCollider)->GetRadius());
 						break;
 					case COLLIDER_CAPSULE:
-						physicsManager.AddCapsuleCollider(*go.physicsBody, static_cast<CapsuleCollider*>(&nCollider)->GetRadius(), static_cast<CapsuleCollider*>(&nCollider)->GetHeight());
+						physicsManager.AddCapsuleCollider(go.GetID(), static_cast<CapsuleCollider*>(&nCollider)->GetRadius(), static_cast<CapsuleCollider*>(&nCollider)->GetHeight());
 						break;
 					default:
 						break;
@@ -596,22 +596,22 @@ void SceneEditor::DrawInspector()
 		//Box
 		if (ImGui::Button("Add Box Collider##box")){
 			if (!inspectedObject->physicsBody)
-				physicsManager.AddPhysicsBody(*inspectedObject);
-			physicsManager.AddBoxCollider(*inspectedObject->physicsBody, {1.0f,1.0f,1.0f});
+				physicsManager.CreatePhysicsBody(inspectedObject->GetID());
+			physicsManager.AddBoxCollider(inspectedObject->GetID(), {1.0f,1.0f,1.0f});
 		}
 
 		//Sphere
 		if (ImGui::Button("Add Sphere Collider##sphere")) {
 			if (!inspectedObject->physicsBody)
-				physicsManager.AddPhysicsBody(*inspectedObject);
-			physicsManager.AddSphereCollider(*inspectedObject->physicsBody, 1.0f);
+				physicsManager.CreatePhysicsBody(inspectedObject->GetID());
+			physicsManager.AddSphereCollider(inspectedObject->GetID(), 1.0f);
 		}
 
 		//Capsule
 		if (ImGui::Button("Add Capsule Collider##capsule")) {
 			if (!inspectedObject->physicsBody)
-				physicsManager.AddPhysicsBody(*inspectedObject);
-			physicsManager.AddCapsuleCollider(*inspectedObject->physicsBody, 1.0f,2.0f);
+				physicsManager.CreatePhysicsBody(inspectedObject->GetID());
+			physicsManager.AddCapsuleCollider(inspectedObject->GetID(), 1.0f,2.0f);
 		}
 
 		static const char* colliderNames[4] = {"Box Collider","Sphere Collider", "Capsule Collider", "Terrain Collider"};


### PR DESCRIPTION
PhysicsManager
- Creating physics body uses ID now instead of GO reference
- collider constructers reflect this change

RigidBody
- removed ID as map in PhysicsManager already contains a map with ID

SceneLoader & SceneEditor
- refactors to accommodate changes to physics body creation
