### PR TITLE
Fix for depenetration bug, velocity now correctly resets when togglin…

### DIFF
--- a/engine/Controller/Editor/SceneEditor.cpp
+++ b/engine/Controller/Editor/SceneEditor.cpp
@@ -585,12 +585,20 @@ void SceneEditor::DrawInspector()
 						if (ImGui::RadioButton("Is Kinematic", inspectedObject->physicsBody->isKinematic))
 						{
 							inspectedObject->physicsBody->isKinematic = !inspectedObject->physicsBody->isKinematic;
+							if (inspectedObject->physicsBody->isKinematic)
+							{
+								inspectedObject->physicsBody->SetVelocity(0.0f, 0.0f, 0.0f);
+							}
 						}
 
 					if (inspectedObject->physicsBody)
 						if (ImGui::RadioButton("Use Gravity", inspectedObject->physicsBody->useGravity))
 						{
 							inspectedObject->physicsBody->useGravity = !inspectedObject->physicsBody->useGravity;
+							if (inspectedObject->physicsBody->useGravity)
+							{
+								inspectedObject->physicsBody->velocity.y = 0.0f;
+							}
 						}
 
 					if (inspectedObject->physicsBody) {

--- a/engine/Controller/Physics/CollisionSolver.cpp
+++ b/engine/Controller/Physics/CollisionSolver.cpp
@@ -32,8 +32,8 @@ void CollisionSolver::ResolvePenetrationLinear(CollisionData& cd)
 	}
 
 	//Average out the corrections
-	totalCorrectionB1 = (totalCorrectionB1 / static_cast<float>(cd.numContacts)) * b1->GetInverseMass();
-	totalCorrectionB2 = (totalCorrectionB2 / static_cast<float>(cd.numContacts)) * b2->GetInverseMass();
+	totalCorrectionB1 = (totalCorrectionB1 / static_cast<float>(cd.numContacts));
+	totalCorrectionB2 = (totalCorrectionB2 / static_cast<float>(cd.numContacts));
 
 	glm::vec3 nb1Pos = b1->GetPosition() + (totalCorrectionB1);
 	glm::vec3 nb2Pos = b2->GetPosition() + (totalCorrectionB2);


### PR DESCRIPTION
…g whether a physics body has gravity or is kinematic. Depenetration issue was being caused a division of inverse mass within the linear depenetration function. The other changes affect the scene editor, simply causing a reset to zero for vertical velocity in the case of a gravity toggle, and a reset to zero for all linear velocity when toggling kinematic